### PR TITLE
fix typo in script/util.lua

### DIFF
--- a/script/util.lua
+++ b/script/util.lua
@@ -10,7 +10,7 @@ end
 function require_ex(name)
   qlog( string.format("require_ex = %s", name))
   if package.loaded[name] then
-    qlog(string.format("require_ex module[%s] reload", mname))
+    qlog(string.format("require_ex module[%s] reload", name))
   end 
   package.loaded[name] = nil 
   require(name)


### PR DESCRIPTION
There is a typo in scriptutil.lua, it will produce a bug below. An error happen when I reload the lua script with the "reload.sh". The log is below.

[20130816 21:49:51 src/qluautil.c:65] load file error
[20130816 21:49:51 src/qluautil.c:66] src/qluautil.c:66 lua_call failed
../script/util.lua:13: bad argument #2 to 'format' (string expected, got nil)

After fix this typo, the server can work normally.
